### PR TITLE
Various paths updates for 4.0 Framework support

### DIFF
--- a/Foreign/Salsa/Binding.hs
+++ b/Foreign/Salsa/Binding.hs
@@ -44,7 +44,7 @@ foreign import ccall "dynamic" make_Type_GetType_stub :: FunPtr Type_GetType_stu
 {-# NOINLINE type_GetType_stub #-}
 type_GetType_stub :: Type_GetType_stub
 type_GetType_stub = make_Type_GetType_stub $ unsafePerformIO $ getMethodStub
-    "System.Type, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" "GetType"
+    "System.Type, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" "GetType"
     "System.String;System.Boolean"
 
 type_GetType typeName = marshalMethod2s type_GetType_stub undefined undefined (typeName, True)
@@ -56,7 +56,7 @@ foreign import ccall "dynamic" make_Type_MakeArrayType_stub :: FunPtr Type_MakeA
 {-# NOINLINE type_MakeArrayType_stub #-}
 type_MakeArrayType_stub :: Type_MakeArrayType_stub
 type_MakeArrayType_stub = make_Type_MakeArrayType_stub $ unsafePerformIO $ getMethodStub
-    "System.Type, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" "MakeArrayType"
+    "System.Type, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" "MakeArrayType"
     "System.Int32"
 
 -- 

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -1,9 +1,9 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
+    <SchemaVersion>4.0</SchemaVersion>
     <ProjectGuid>{53648C35-67B5-4903-999C-54B19F4DEE75}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -11,7 +11,6 @@
     <AssemblyName>Generator</AssemblyName>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
-    <OldToolsVersion>2.0</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <PublishUrl>publish\</PublishUrl>
@@ -29,7 +28,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,9 +49,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Generator.cs" />
@@ -75,6 +72,16 @@
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
       <Visible>False</Visible>
       <ProductName>.NET Framework 3.5</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.4.0">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 4.0</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.4.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 4.5</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>

--- a/Samples/Conway/Conway.imports
+++ b/Samples/Conway/Conway.imports
@@ -1,7 +1,7 @@
-reference C:\Windows\Microsoft.NET\Framework\v2.0.50727\System.dll
-reference C:\Program Files\Reference Assemblies\Microsoft\Framework\v3.0\PresentationCore.dll
-reference C:\Program Files\Reference Assemblies\Microsoft\Framework\v3.0\PresentationFramework.dll 
-reference C:\Program Files\Reference Assemblies\Microsoft\Framework\v3.0\WindowsBase.dll
+reference C:\Windows\Microsoft.NET\Framework\v4.0.30319\System.dll
+reference C:\Program Files\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\PresentationCore.dll
+reference C:\Program Files\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\PresentationFramework.dll 
+reference C:\Program Files\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\WindowsBase.dll
 
 System.Windows.Controls.Primitives.ToggleButton: IsChecked
 

--- a/Samples/Conway/Conway.proj
+++ b/Samples/Conway/Conway.proj
@@ -33,7 +33,7 @@
   <!-- Run GHC to build the main program -->
   <Target Name="Build"
           DependsOnTargets="GenerateBindings">
-    <Exec Command="ghc --make $(Module) -fglasgow-exts -threaded" />
+    <Exec Command="ghc --make $(Module) -XMagicHash -threaded" />
   </Target>
 
   <Target Name="Clean" >

--- a/Samples/Hello/Hello.imports
+++ b/Samples/Hello/Hello.imports
@@ -1,2 +1,2 @@
-reference C:\Windows\Microsoft.NET\Framework\v2.0.50727\System.dll
+reference C:\Windows\Microsoft.NET\Framework\v4.0.30319\System.dll
 System.Console: WriteLine

--- a/Samples/Hello/Hello.proj
+++ b/Samples/Hello/Hello.proj
@@ -33,7 +33,7 @@
   <!-- Run GHC to build the main program -->
   <Target Name="Build"
           DependsOnTargets="GenerateBindings">
-    <Exec Command="ghc --make $(Module) -fglasgow-exts -threaded" />
+    <Exec Command="ghc --make $(Module) -XMagicHash -threaded" />
   </Target>
 
   <Target Name="Clean" >

--- a/Samples/Weather/Weather.imports
+++ b/Samples/Weather/Weather.imports
@@ -1,4 +1,4 @@
-reference C:\Windows\Microsoft.NET\Framework\v2.0.50727\System.dll
+reference C:\Windows\Microsoft.NET\Framework\v4.0.30319\System.dll
 System.Console: WriteLine
 System.Net.WebClient: DownloadStringAsync, DownloadStringCompleted, DownloadString, DownloadStringCompletedEventHandler
 System.Net.DownloadStringCompletedEventArgs: Result, UserState

--- a/Samples/Weather/Weather.proj
+++ b/Samples/Weather/Weather.proj
@@ -33,7 +33,7 @@
   <!-- Run GHC to build the main program -->
   <Target Name="Build"
           DependsOnTargets="GenerateBindings">
-    <Exec Command="ghc --make $(Module) -fglasgow-exts -threaded" />
+    <Exec Command="ghc --make $(Module) -XMagicHash -threaded" />
   </Target>
 
   <Target Name="Clean" >


### PR DESCRIPTION
Also  `-fglasgow-exts` is deprecated and here I'm not sure if my replacement makes sense.